### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/tap2junit/tap13.py
+++ b/tap2junit/tap13.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright 2013, Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -189,6 +190,6 @@ if __name__ == "__main__":
 
     import pprint
     for test in t.tests:
-        print test.result, test.id, test.description, "#", test.directive, test.comment
+        print(test.result, test.id, test.description, "#", test.directive, test.comment)
         pprint.pprint(test.yaml_buffer)
         pprint.pprint(test.yaml)


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

As discussed at https://github.com/nodejs/build/pull/1836#issuecomment-502066381